### PR TITLE
Cluster History account with blocks per epoch tracking

### DIFF
--- a/keepers/validator-keeper/src/cluster_info.rs
+++ b/keepers/validator-keeper/src/cluster_info.rs
@@ -1,0 +1,31 @@
+use std::sync::Arc;
+
+use anchor_lang::{InstructionData, ToAccountMetas};
+use keeper_core::{submit_instructions, SubmitStats, TransactionExecutionError};
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::{instruction::Instruction, pubkey::Pubkey, signature::Keypair, signer::Signer};
+use validator_history::state::ClusterHistory;
+
+pub async fn update_cluster_info(
+    client: Arc<RpcClient>,
+    keypair: Arc<Keypair>,
+    program_id: &Pubkey,
+) -> Result<SubmitStats, (TransactionExecutionError, SubmitStats)> {
+    // literally just build one instruction and submit it...
+
+    let (cluster_history_account, _) =
+        Pubkey::find_program_address(&[ClusterHistory::SEED], program_id);
+
+    let update_instruction = Instruction {
+        program_id: *program_id,
+        accounts: validator_history::accounts::CopyClusterInfo {
+            cluster_history_account,
+            slot_history: solana_program::sysvar::slot_history::id(),
+            signer: keypair.pubkey(),
+        }
+        .to_account_metas(None),
+        data: validator_history::instruction::CopyClusterInfo {}.data(),
+    };
+
+    submit_instructions(&client, vec![update_instruction], &keypair).await
+}

--- a/keepers/validator-keeper/src/cluster_info.rs
+++ b/keepers/validator-keeper/src/cluster_info.rs
@@ -11,8 +11,6 @@ pub async fn update_cluster_info(
     keypair: Arc<Keypair>,
     program_id: &Pubkey,
 ) -> Result<SubmitStats, (TransactionExecutionError, SubmitStats)> {
-    // literally just build one instruction and submit it...
-
     let (cluster_history_account, _) =
         Pubkey::find_program_address(&[ClusterHistory::SEED], program_id);
 

--- a/programs/validator-history/src/errors.rs
+++ b/programs/validator-history/src/errors.rs
@@ -24,4 +24,6 @@ pub enum ValidatorHistoryError {
     GossipDataInFuture,
     #[msg("Arithmetic Error (overflow/underflow)")]
     ArithmeticError,
+    #[msg("Slot history sysvar is not containing expected slots")]
+    SlotHistoryOutOfDate,
 }

--- a/programs/validator-history/src/instructions/backfill_total_blocks.rs
+++ b/programs/validator-history/src/instructions/backfill_total_blocks.rs
@@ -1,0 +1,25 @@
+use anchor_lang::prelude::*;
+
+use crate::{utils::cast_epoch, ClusterHistory, Config};
+
+#[derive(Accounts)]
+pub struct BackfillTotalBlocks<'info> {
+    #[account(
+        mut,
+        seeds = [ClusterHistory::SEED],
+        bump,
+    )]
+    pub cluster_history_account: AccountLoader<'info, ClusterHistory>,
+    pub config: Account<'info, Config>,
+    #[account(mut, address = config.stake_authority )]
+    pub signer: Signer<'info>,
+}
+
+pub fn handler(ctx: Context<BackfillTotalBlocks>, epoch: u64, blocks_in_epoch: u32) -> Result<()> {
+    let mut cluster_history_account = ctx.accounts.cluster_history_account.load_mut()?;
+
+    let epoch = cast_epoch(epoch);
+    cluster_history_account.set_blocks(epoch, blocks_in_epoch)?;
+
+    Ok(())
+}

--- a/programs/validator-history/src/instructions/backfill_total_blocks.rs
+++ b/programs/validator-history/src/instructions/backfill_total_blocks.rs
@@ -20,7 +20,7 @@ pub fn handler(ctx: Context<BackfillTotalBlocks>, epoch: u64, blocks_in_epoch: u
 
     let epoch = cast_epoch(epoch);
 
-    // Need to backfill in ascending order when initially filling in the account
+    // Need to backfill in ascending order when initially filling in the account otherwise entries will be out of order
     if !cluster_history_account.history.is_empty()
         && epoch != cluster_history_account.history.last().unwrap().epoch + 1
     {

--- a/programs/validator-history/src/instructions/backfill_total_blocks.rs
+++ b/programs/validator-history/src/instructions/backfill_total_blocks.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-use crate::{utils::cast_epoch, ClusterHistory, Config};
+use crate::{errors::ValidatorHistoryError, utils::cast_epoch, ClusterHistory, Config};
 
 #[derive(Accounts)]
 pub struct BackfillTotalBlocks<'info> {
@@ -19,6 +19,13 @@ pub fn handler(ctx: Context<BackfillTotalBlocks>, epoch: u64, blocks_in_epoch: u
     let mut cluster_history_account = ctx.accounts.cluster_history_account.load_mut()?;
 
     let epoch = cast_epoch(epoch);
+
+    // Need to backfill in ascending order when initially filling in the account
+    if !cluster_history_account.history.is_empty()
+        && epoch != cluster_history_account.history.last().unwrap().epoch + 1
+    {
+        return Err(ValidatorHistoryError::EpochOutOfRange.into());
+    }
     cluster_history_account.set_blocks(epoch, blocks_in_epoch)?;
 
     Ok(())

--- a/programs/validator-history/src/instructions/copy_cluster_info.rs
+++ b/programs/validator-history/src/instructions/copy_cluster_info.rs
@@ -1,0 +1,54 @@
+use anchor_lang::{
+    prelude::*,
+    solana_program::{clock::Clock, slot_history::Check},
+};
+
+use crate::{errors::ValidatorHistoryError, utils::cast_epoch, ClusterHistory};
+
+#[derive(Accounts)]
+pub struct CopyClusterInfo<'info> {
+    #[account(
+        mut,
+        seeds = [ClusterHistory::SEED],
+        bump,
+    )]
+    pub cluster_history_account: AccountLoader<'info, ClusterHistory>,
+    #[account(mut)]
+    pub signer: Signer<'info>,
+}
+
+pub fn handler(ctx: Context<CopyClusterInfo>) -> Result<()> {
+    let mut cluster_history_account = ctx.accounts.cluster_history_account.load_mut()?;
+    let clock = Clock::get()?;
+
+    let epoch_schedule = EpochSchedule::get()?;
+    let slot_history = SlotHistory::get()?;
+
+    let start_slot = epoch_schedule.get_first_slot_in_epoch(clock.epoch - 1);
+    let end_slot = epoch_schedule.get_first_slot_in_epoch(clock.epoch);
+
+    let mut blocks_in_epoch = 0;
+    for i in start_slot..end_slot {
+        match slot_history.check(i) {
+            Check::Found => {
+                blocks_in_epoch += 1;
+            }
+            Check::NotFound => {
+                // do nothing
+            }
+            Check::TooOld => {
+                return Err(ValidatorHistoryError::SlotHistoryOutOfDate.into());
+            }
+            Check::Future => {
+                return Err(ValidatorHistoryError::SlotHistoryOutOfDate.into());
+            }
+        };
+    }
+
+    let epoch = cast_epoch(clock.epoch);
+
+    // Sets the slot history for the previous epoch, since the current epoch is not yet complete.
+    cluster_history_account.set_blocks(epoch - 1, blocks_in_epoch)?;
+
+    Ok(())
+}

--- a/programs/validator-history/src/instructions/copy_cluster_info.rs
+++ b/programs/validator-history/src/instructions/copy_cluster_info.rs
@@ -28,7 +28,10 @@ pub fn handler(ctx: Context<CopyClusterInfo>) -> Result<()> {
     let epoch = cast_epoch(clock.epoch);
 
     // Sets the slot history for the previous epoch, since the current epoch is not yet complete.
-    cluster_history_account.set_blocks(epoch - 1, blocks_in_epoch(epoch - 1, &slot_history)?)?;
+    if epoch > 0 {
+        cluster_history_account
+            .set_blocks(epoch - 1, blocks_in_epoch(epoch - 1, &slot_history)?)?;
+    }
     cluster_history_account.set_blocks(epoch, blocks_in_epoch(epoch, &slot_history)?)?;
 
     cluster_history_account.cluster_history_last_update_slot = clock.slot;

--- a/programs/validator-history/src/instructions/copy_cluster_info.rs
+++ b/programs/validator-history/src/instructions/copy_cluster_info.rs
@@ -24,13 +24,25 @@ pub fn handler(ctx: Context<CopyClusterInfo>) -> Result<()> {
         Box::new(bincode::deserialize(&ctx.accounts.slot_history.try_borrow_data()?).unwrap());
 
     let clock = Clock::get()?;
-    let epoch_schedule = EpochSchedule::get()?;
 
-    let start_slot = epoch_schedule.get_first_slot_in_epoch(clock.epoch - 1);
-    let end_slot = epoch_schedule.get_first_slot_in_epoch(clock.epoch);
+    let epoch = cast_epoch(clock.epoch);
+
+    // Sets the slot history for the previous epoch, since the current epoch is not yet complete.
+    cluster_history_account.set_blocks(epoch - 1, blocks_in_epoch(epoch - 1, &slot_history)?)?;
+    cluster_history_account.set_blocks(epoch, blocks_in_epoch(epoch, &slot_history)?)?;
+
+    cluster_history_account.cluster_history_last_update_slot = clock.slot;
+
+    Ok(())
+}
+
+fn blocks_in_epoch(epoch: u16, slot_history: &Box<SlotHistory>) -> Result<u32> {
+    let epoch_schedule = EpochSchedule::get()?;
+    let start_slot = epoch_schedule.get_first_slot_in_epoch(epoch as u64);
+    let end_slot = epoch_schedule.get_last_slot_in_epoch(epoch as u64);
 
     let mut blocks_in_epoch = 0;
-    for i in start_slot..end_slot {
+    for i in start_slot..=end_slot {
         match slot_history.check(i) {
             Check::Found => {
                 blocks_in_epoch += 1;
@@ -42,15 +54,10 @@ pub fn handler(ctx: Context<CopyClusterInfo>) -> Result<()> {
                 return Err(ValidatorHistoryError::SlotHistoryOutOfDate.into());
             }
             Check::Future => {
-                return Err(ValidatorHistoryError::SlotHistoryOutOfDate.into());
+                // do nothing
             }
         };
     }
 
-    let epoch = cast_epoch(clock.epoch);
-
-    // Sets the slot history for the previous epoch, since the current epoch is not yet complete.
-    cluster_history_account.set_blocks(epoch - 1, blocks_in_epoch)?;
-
-    Ok(())
+    Ok(blocks_in_epoch)
 }

--- a/programs/validator-history/src/instructions/copy_cluster_info.rs
+++ b/programs/validator-history/src/instructions/copy_cluster_info.rs
@@ -13,16 +13,18 @@ pub struct CopyClusterInfo<'info> {
         bump,
     )]
     pub cluster_history_account: AccountLoader<'info, ClusterHistory>,
+    pub slot_history: UncheckedAccount<'info>,
     #[account(mut)]
     pub signer: Signer<'info>,
 }
 
 pub fn handler(ctx: Context<CopyClusterInfo>) -> Result<()> {
     let mut cluster_history_account = ctx.accounts.cluster_history_account.load_mut()?;
-    let clock = Clock::get()?;
+    let slot_history: Box<SlotHistory> =
+        Box::new(bincode::deserialize(&ctx.accounts.slot_history.try_borrow_data()?).unwrap());
 
+    let clock = Clock::get()?;
     let epoch_schedule = EpochSchedule::get()?;
-    let slot_history = SlotHistory::get()?;
 
     let start_slot = epoch_schedule.get_first_slot_in_epoch(clock.epoch - 1);
     let end_slot = epoch_schedule.get_first_slot_in_epoch(clock.epoch);

--- a/programs/validator-history/src/instructions/initialize_cluster_history_account.rs
+++ b/programs/validator-history/src/instructions/initialize_cluster_history_account.rs
@@ -1,0 +1,21 @@
+use crate::{constants::MAX_ALLOC_BYTES, state::ValidatorHistory, ClusterHistory};
+use anchor_lang::prelude::*;
+
+#[derive(Accounts)]
+pub struct InitializeClusterHistoryAccount<'info> {
+    #[account(
+        init,
+        payer = signer,
+        space = MAX_ALLOC_BYTES,
+        seeds = [ClusterHistory::SEED, ],
+        bump
+    )]
+    pub validator_history_account: AccountLoader<'info, ValidatorHistory>,
+    pub system_program: Program<'info, System>,
+    #[account(mut)]
+    pub signer: Signer<'info>,
+}
+
+pub fn handler(_: Context<InitializeClusterHistoryAccount>) -> Result<()> {
+    Ok(())
+}

--- a/programs/validator-history/src/instructions/initialize_cluster_history_account.rs
+++ b/programs/validator-history/src/instructions/initialize_cluster_history_account.rs
@@ -1,4 +1,4 @@
-use crate::{constants::MAX_ALLOC_BYTES, state::ValidatorHistory, ClusterHistory};
+use crate::{constants::MAX_ALLOC_BYTES, ClusterHistory};
 use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
@@ -7,10 +7,10 @@ pub struct InitializeClusterHistoryAccount<'info> {
         init,
         payer = signer,
         space = MAX_ALLOC_BYTES,
-        seeds = [ClusterHistory::SEED, ],
+        seeds = [ClusterHistory::SEED],
         bump
     )]
-    pub validator_history_account: AccountLoader<'info, ValidatorHistory>,
+    pub cluster_history_account: AccountLoader<'info, ClusterHistory>,
     pub system_program: Program<'info, System>,
     #[account(mut)]
     pub signer: Signer<'info>,

--- a/programs/validator-history/src/instructions/mod.rs
+++ b/programs/validator-history/src/instructions/mod.rs
@@ -1,8 +1,11 @@
 #![allow(ambiguous_glob_reexports)]
+pub mod copy_cluster_info;
 pub mod copy_gossip_contact_info;
 pub mod copy_vote_account;
+pub mod initialize_cluster_history_account;
 pub mod initialize_config;
 pub mod initialize_validator_history_account;
+pub mod realloc_cluster_history_account;
 pub mod realloc_validator_history_account;
 pub mod set_new_stake_authority;
 pub mod set_new_tip_distribution_authority;
@@ -10,10 +13,13 @@ pub mod set_new_tip_distribution_program;
 pub mod update_mev_commission;
 pub mod update_stake_history;
 
+pub use copy_cluster_info::*;
 pub use copy_gossip_contact_info::*;
 pub use copy_vote_account::*;
+pub use initialize_cluster_history_account::*;
 pub use initialize_config::*;
 pub use initialize_validator_history_account::*;
+pub use realloc_cluster_history_account::*;
 pub use realloc_validator_history_account::*;
 pub use set_new_stake_authority::*;
 pub use set_new_tip_distribution_authority::*;

--- a/programs/validator-history/src/instructions/mod.rs
+++ b/programs/validator-history/src/instructions/mod.rs
@@ -1,4 +1,5 @@
 #![allow(ambiguous_glob_reexports)]
+pub mod backfill_total_blocks;
 pub mod copy_cluster_info;
 pub mod copy_gossip_contact_info;
 pub mod copy_vote_account;
@@ -13,6 +14,7 @@ pub mod set_new_tip_distribution_program;
 pub mod update_mev_commission;
 pub mod update_stake_history;
 
+pub use backfill_total_blocks::*;
 pub use copy_cluster_info::*;
 pub use copy_gossip_contact_info::*;
 pub use copy_vote_account::*;

--- a/programs/validator-history/src/instructions/realloc_cluster_history_account.rs
+++ b/programs/validator-history/src/instructions/realloc_cluster_history_account.rs
@@ -16,7 +16,7 @@ fn is_initialized(account_info: &AccountInfo) -> Result<bool> {
     let account_data = account_info.as_ref().try_borrow_data()?;
 
     // discriminator + version_number
-    let vote_account_pubkey_bytes = account_data[(8 + 4)..(8 + 4 + 32)].to_vec();
+    let vote_account_pubkey_bytes = account_data[(8 + 8)..(8 + 8 + 32)].to_vec();
 
     // If pubkey is all zeroes, then it's not initialized
     Ok(vote_account_pubkey_bytes.iter().any(|&x| x != 0))

--- a/programs/validator-history/src/instructions/realloc_cluster_history_account.rs
+++ b/programs/validator-history/src/instructions/realloc_cluster_history_account.rs
@@ -1,0 +1,65 @@
+use crate::{
+    constants::MAX_ALLOC_BYTES, state::ValidatorHistory, ClusterHistory, ClusterHistoryEntry,
+};
+use anchor_lang::prelude::*;
+
+fn get_realloc_size(account_info: &AccountInfo) -> usize {
+    let account_size = account_info.data_len();
+
+    // If account is already over-allocated, don't try to shrink
+    if account_size < ValidatorHistory::SIZE {
+        ValidatorHistory::SIZE.min(account_size + MAX_ALLOC_BYTES)
+    } else {
+        account_size
+    }
+}
+
+// TODO need to find a thing that's initialized here, maybe is_initialized field
+fn is_initialized(account_info: &AccountInfo) -> Result<bool> {
+    let account_data = account_info.as_ref().try_borrow_data()?;
+
+    // discriminator + version_number
+    let vote_account_pubkey_bytes = account_data[(8 + 4)..(8 + 4 + 32)].to_vec();
+
+    // If pubkey is all zeroes, then it's not initialized
+    Ok(vote_account_pubkey_bytes.iter().any(|&x| x != 0))
+}
+
+#[derive(Accounts)]
+pub struct ReallocClusterHistoryAccount<'info> {
+    #[account(
+        mut,
+        realloc = get_realloc_size(cluster_history_account.as_ref()),
+        realloc::payer = signer,
+        realloc::zero = false,
+        seeds = [ValidatorHistory::SEED ],
+        bump
+    )]
+    pub cluster_history_account: AccountLoader<'info, ClusterHistory>,
+    pub system_program: Program<'info, System>,
+    #[account(mut)]
+    pub signer: Signer<'info>,
+}
+
+pub fn handler(ctx: Context<ReallocClusterHistoryAccount>) -> Result<()> {
+    let account_size = ctx.accounts.cluster_history_account.as_ref().data_len();
+    if account_size >= ClusterHistory::SIZE
+        && !is_initialized(ctx.accounts.cluster_history_account.as_ref())?
+    {
+        // Can actually initialize values now that the account is proper size
+        let mut cluster_history_account = ctx.accounts.cluster_history_account.load_mut()?;
+
+        cluster_history_account.bump = *ctx.bumps.get("cluster_history_account").unwrap();
+        cluster_history_account.struct_version = 0; // TODO make a struct
+        cluster_history_account.history.idx =
+            (cluster_history_account.history.arr.len() - 1) as u64;
+        for _ in 0..cluster_history_account.history.arr.len() {
+            cluster_history_account
+                .history
+                .push(ClusterHistoryEntry::default());
+        }
+        cluster_history_account.history.is_empty = 1;
+    }
+
+    Ok(())
+}

--- a/programs/validator-history/src/instructions/realloc_cluster_history_account.rs
+++ b/programs/validator-history/src/instructions/realloc_cluster_history_account.rs
@@ -1,14 +1,12 @@
-use crate::{
-    constants::MAX_ALLOC_BYTES, state::ValidatorHistory, ClusterHistory, ClusterHistoryEntry,
-};
+use crate::{constants::MAX_ALLOC_BYTES, ClusterHistory, ClusterHistoryEntry};
 use anchor_lang::prelude::*;
 
 fn get_realloc_size(account_info: &AccountInfo) -> usize {
     let account_size = account_info.data_len();
 
     // If account is already over-allocated, don't try to shrink
-    if account_size < ValidatorHistory::SIZE {
-        ValidatorHistory::SIZE.min(account_size + MAX_ALLOC_BYTES)
+    if account_size < ClusterHistory::SIZE {
+        ClusterHistory::SIZE.min(account_size + MAX_ALLOC_BYTES)
     } else {
         account_size
     }
@@ -32,7 +30,7 @@ pub struct ReallocClusterHistoryAccount<'info> {
         realloc = get_realloc_size(cluster_history_account.as_ref()),
         realloc::payer = signer,
         realloc::zero = false,
-        seeds = [ValidatorHistory::SEED ],
+        seeds = [ClusterHistory::SEED],
         bump
     )]
     pub cluster_history_account: AccountLoader<'info, ClusterHistory>,

--- a/programs/validator-history/src/instructions/realloc_cluster_history_account.rs
+++ b/programs/validator-history/src/instructions/realloc_cluster_history_account.rs
@@ -12,7 +12,6 @@ fn get_realloc_size(account_info: &AccountInfo) -> usize {
     }
 }
 
-// TODO need to find a thing that's initialized here, maybe is_initialized field
 fn is_initialized(account_info: &AccountInfo) -> Result<bool> {
     let account_data = account_info.as_ref().try_borrow_data()?;
 
@@ -48,7 +47,7 @@ pub fn handler(ctx: Context<ReallocClusterHistoryAccount>) -> Result<()> {
         let mut cluster_history_account = ctx.accounts.cluster_history_account.load_mut()?;
 
         cluster_history_account.bump = *ctx.bumps.get("cluster_history_account").unwrap();
-        cluster_history_account.struct_version = 0; // TODO make a struct
+        cluster_history_account.struct_version = 0;
         cluster_history_account.history.idx =
             (cluster_history_account.history.arr.len() - 1) as u64;
         for _ in 0..cluster_history_account.history.arr.len() {

--- a/programs/validator-history/src/lib.rs
+++ b/programs/validator-history/src/lib.rs
@@ -53,6 +53,18 @@ pub mod validator_history {
         instructions::realloc_validator_history_account::handler(ctx)
     }
 
+    pub fn initialize_cluster_history_account(
+        ctx: Context<InitializeClusterHistoryAccount>,
+    ) -> Result<()> {
+        instructions::initialize_cluster_history_account::handler(ctx)
+    }
+
+    pub fn realloc_cluster_history_account(
+        ctx: Context<ReallocClusterHistoryAccount>,
+    ) -> Result<()> {
+        instructions::realloc_cluster_history_account::handler(ctx)
+    }
+
     pub fn copy_vote_account(ctx: Context<CopyVoteAccount>) -> Result<()> {
         instructions::copy_vote_account::handler(ctx)
     }
@@ -93,5 +105,9 @@ pub mod validator_history {
 
     pub fn copy_gossip_contact_info(ctx: Context<CopyGossipContactInfo>) -> Result<()> {
         instructions::copy_gossip_contact_info::handler(ctx)
+    }
+
+    pub fn copy_slot_index(ctx: Context<CopyClusterInfo>) -> Result<()> {
+        instructions::copy_cluster_info::handler(ctx)
     }
 }

--- a/programs/validator-history/src/lib.rs
+++ b/programs/validator-history/src/lib.rs
@@ -107,7 +107,15 @@ pub mod validator_history {
         instructions::copy_gossip_contact_info::handler(ctx)
     }
 
-    pub fn copy_slot_index(ctx: Context<CopyClusterInfo>) -> Result<()> {
+    pub fn copy_cluster_info(ctx: Context<CopyClusterInfo>) -> Result<()> {
         instructions::copy_cluster_info::handler(ctx)
+    }
+
+    pub fn backfill_total_blocks(
+        ctx: Context<BackfillTotalBlocks>,
+        epoch: u64,
+        blocks_in_epoch: u32,
+    ) -> Result<()> {
+        instructions::backfill_total_blocks::handler(ctx, epoch, blocks_in_epoch)
     }
 }

--- a/programs/validator-history/src/state.rs
+++ b/programs/validator-history/src/state.rs
@@ -529,6 +529,8 @@ pub struct ClusterHistory {
     pub struct_version: u64,
     pub bump: u8,
     pub _padding0: [u8; 7],
+    pub cluster_history_last_update_slot: u64,
+    pub _padding1: [u8; 232],
     pub history: CircBufCluster,
 }
 
@@ -536,7 +538,7 @@ pub struct ClusterHistory {
 pub struct ClusterHistoryEntry {
     pub total_blocks: u32,
     pub epoch: u16,
-    pub padding: [u8; 122],
+    pub padding: [u8; 250],
 }
 
 impl Default for ClusterHistoryEntry {
@@ -544,7 +546,7 @@ impl Default for ClusterHistoryEntry {
         Self {
             total_blocks: u32::MAX,
             epoch: u16::MAX,
-            padding: [u8::MAX; 122],
+            padding: [u8::MAX; 250],
         }
     }
 }

--- a/programs/validator-history/src/state.rs
+++ b/programs/validator-history/src/state.rs
@@ -526,7 +526,7 @@ impl ValidatorHistory {
 
 #[account(zero_copy)]
 pub struct ClusterHistory {
-    pub struct_version: u64, // TODO tweak
+    pub struct_version: u64,
     pub bump: u8,
     pub _padding0: [u8; 7],
     pub history: CircBufCluster,

--- a/tests/src/fixtures.rs
+++ b/tests/src/fixtures.rs
@@ -17,12 +17,13 @@ use std::{cell::RefCell, rc::Rc};
 use jito_tip_distribution::{
     sdk::derive_tip_distribution_account_address, state::TipDistributionAccount,
 };
-use validator_history::{self, constants::MAX_ALLOC_BYTES, ValidatorHistory};
+use validator_history::{self, constants::MAX_ALLOC_BYTES, ClusterHistory, ValidatorHistory};
 
 pub struct TestFixture {
     pub ctx: Rc<RefCell<ProgramTestContext>>,
     pub vote_account: Pubkey,
     pub identity_keypair: Keypair,
+    pub cluster_history_account: Pubkey,
     pub validator_history_account: Pubkey,
     pub validator_history_config: Pubkey,
     pub tip_distribution_account: Pubkey,
@@ -52,6 +53,8 @@ impl TestFixture {
         let vote_account = Pubkey::new_unique();
         let identity_keypair = Keypair::new();
         let identity_pubkey = identity_keypair.pubkey();
+        let cluster_history_account =
+            Pubkey::find_program_address(&[ClusterHistory::SEED], &validator_history::id()).0;
         let tip_distribution_account = derive_tip_distribution_account_address(
             &jito_tip_distribution::id(),
             &vote_account,
@@ -85,6 +88,7 @@ impl TestFixture {
             ctx,
             validator_history_config,
             validator_history_account,
+            cluster_history_account,
             identity_keypair,
             vote_account,
             tip_distribution_account,
@@ -178,6 +182,44 @@ impl TestFixture {
                 }
                 .to_account_metas(None),
                 data: validator_history::instruction::ReallocValidatorHistoryAccount {}.data(),
+            };
+            num_reallocs
+        ]);
+        let transaction = Transaction::new_signed_with_payer(
+            &ixs,
+            Some(&self.keypair.pubkey()),
+            &[&self.keypair],
+            self.ctx.borrow().last_blockhash,
+        );
+        self.submit_transaction_assert_success(transaction).await;
+    }
+
+    pub async fn initialize_cluster_history_account(&self) {
+        let instruction = Instruction {
+            program_id: validator_history::id(),
+            accounts: validator_history::accounts::InitializeClusterHistoryAccount {
+                cluster_history_account: self.cluster_history_account,
+                system_program: anchor_lang::solana_program::system_program::id(),
+                signer: self.keypair.pubkey(),
+            }
+            .to_account_metas(None),
+            data: validator_history::instruction::InitializeClusterHistoryAccount {}.data(),
+        };
+
+        let mut ixs = vec![instruction];
+
+        // Realloc cluster history account
+        let num_reallocs = (ClusterHistory::SIZE - MAX_ALLOC_BYTES) / MAX_ALLOC_BYTES + 1;
+        ixs.extend(vec![
+            Instruction {
+                program_id: validator_history::id(),
+                accounts: validator_history::accounts::ReallocClusterHistoryAccount {
+                    cluster_history_account: self.cluster_history_account,
+                    system_program: anchor_lang::solana_program::system_program::id(),
+                    signer: self.keypair.pubkey(),
+                }
+                .to_account_metas(None),
+                data: validator_history::instruction::ReallocClusterHistoryAccount {}.data(),
             };
             num_reallocs
         ]);

--- a/tests/tests/test_cluster_history.rs
+++ b/tests/tests/test_cluster_history.rs
@@ -26,6 +26,8 @@ async fn test_copy_cluster_info() {
 
     let latest_slot = ctx.borrow_mut().banks_client.get_root_slot().await.unwrap();
     slot_history.add(latest_slot);
+    slot_history.add(latest_slot + 1);
+    println!("latest_slot: {}", latest_slot);
 
     // Submit instruction
     let instruction = Instruction {
@@ -61,7 +63,10 @@ async fn test_copy_cluster_info() {
         .expect("clock");
 
     assert!(clock.epoch == 1);
-    assert!(account.history.idx == 0);
+    assert!(account.history.idx == 1);
     assert!(account.history.arr[0].epoch == 0);
     assert!(account.history.arr[0].total_blocks == 3);
+    assert!(account.history.arr[1].epoch == 1);
+    assert!(account.history.arr[1].total_blocks == 2);
+    assert_eq!(account.cluster_history_last_update_slot, latest_slot)
 }

--- a/tests/tests/test_cluster_history.rs
+++ b/tests/tests/test_cluster_history.rs
@@ -1,0 +1,67 @@
+#![allow(clippy::await_holding_refcell_ref)]
+use anchor_lang::{
+    solana_program::{instruction::Instruction, slot_history::SlotHistory},
+    InstructionData, ToAccountMetas,
+};
+use solana_program_test::*;
+use solana_sdk::{clock::Clock, signer::Signer, transaction::Transaction};
+use tests::fixtures::TestFixture;
+use validator_history::ClusterHistory;
+
+#[tokio::test]
+async fn test_copy_cluster_info() {
+    // Initialize
+    let fixture = TestFixture::new().await;
+    let ctx = &fixture.ctx;
+    fixture.initialize_config().await;
+    fixture.initialize_cluster_history_account().await;
+
+    fixture.advance_num_epochs(1).await;
+
+    // Set SlotHistory sysvar with a few slots
+    let mut slot_history = SlotHistory::default();
+    slot_history.add(0);
+    slot_history.add(1);
+    slot_history.add(2);
+
+    let latest_slot = ctx.borrow_mut().banks_client.get_root_slot().await.unwrap();
+    slot_history.add(latest_slot);
+
+    // Submit instruction
+    let instruction = Instruction {
+        program_id: validator_history::id(),
+        data: validator_history::instruction::CopyClusterInfo {}.data(),
+        accounts: validator_history::accounts::CopyClusterInfo {
+            cluster_history_account: fixture.cluster_history_account,
+            slot_history: anchor_lang::solana_program::sysvar::slot_history::id(),
+            signer: fixture.keypair.pubkey(),
+        }
+        .to_account_metas(None),
+    };
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&fixture.keypair.pubkey()),
+        &[&fixture.keypair],
+        ctx.borrow().last_blockhash,
+    );
+
+    ctx.borrow_mut().set_sysvar(&slot_history);
+    fixture.submit_transaction_assert_success(transaction).await;
+
+    let account: ClusterHistory = fixture
+        .load_and_deserialize(&fixture.cluster_history_account)
+        .await;
+
+    let clock: Clock = ctx
+        .borrow_mut()
+        .banks_client
+        .get_sysvar()
+        .await
+        .expect("clock");
+
+    assert!(clock.epoch == 1);
+    assert!(account.history.idx == 0);
+    assert!(account.history.arr[0].epoch == 0);
+    assert!(account.history.arr[0].total_blocks == 3);
+}

--- a/utils/validator-history-cli/src/main.rs
+++ b/utils/validator-history-cli/src/main.rs
@@ -11,7 +11,9 @@ use solana_program::instruction::Instruction;
 use solana_sdk::{
     pubkey::Pubkey, signature::read_keypair_file, signer::Signer, transaction::Transaction,
 };
-use validator_history::{Config, ValidatorHistory, ValidatorHistoryEntry};
+use validator_history::{
+    constants::MAX_ALLOC_BYTES, ClusterHistory, Config, ValidatorHistory, ValidatorHistoryEntry,
+};
 
 #[derive(Parser)]
 #[command(about = "CLI for validator history program")]
@@ -32,8 +34,10 @@ struct Args {
 #[derive(Subcommand)]
 enum Commands {
     InitConfig(InitConfig),
+    InitClusterHistory(InitClusterHistory),
     CrankerStatus(CrankerStatus),
     History(History),
+    BackfillClusterHistory(BackfillClusterHistory),
 }
 
 #[derive(Parser)]
@@ -60,6 +64,14 @@ struct InitConfig {
     stake_authority: Option<Pubkey>,
 }
 
+#[derive(Parser)]
+#[command(about = "Initialize cluster history account")]
+struct InitClusterHistory {
+    /// Path to keypair used to pay for account creation and execute transactions
+    #[arg(short, long, env, default_value = "~/.config/solana/id.json")]
+    keypair_path: PathBuf,
+}
+
 #[derive(Parser, Debug)]
 #[command(about = "Get cranker status")]
 struct CrankerStatus {
@@ -77,6 +89,22 @@ struct History {
     /// Start epoch
     #[arg(short, long, env)]
     start_epoch: Option<u64>,
+}
+
+#[derive(Parser)]
+#[command(about = "Backfill cluster history")]
+struct BackfillClusterHistory {
+    /// Path to keypair used to pay for account creation and execute transactions
+    #[arg(short, long, env, default_value = "~/.config/solana/id.json")]
+    keypair_path: PathBuf,
+
+    /// Epoch to backfill
+    #[arg(short, long, env)]
+    epoch: u64,
+
+    /// Number of blocks in epoch
+    #[arg(short, long, env)]
+    blocks_in_epoch: u32,
 }
 
 fn command_init_config(args: InitConfig, client: RpcClient) {
@@ -135,6 +163,55 @@ fn command_init_config(args: InitConfig, client: RpcClient) {
             data: validator_history::instruction::SetNewStakeAuthority {}.data(),
         });
     }
+
+    let blockhash = client
+        .get_latest_blockhash()
+        .expect("Failed to get recent blockhash");
+    let transaction = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&keypair.pubkey()),
+        &[&keypair],
+        blockhash,
+    );
+
+    let signature = client
+        .send_and_confirm_transaction_with_spinner(&transaction)
+        .expect("Failed to send transaction");
+    println!("Signature: {}", signature);
+}
+
+fn command_init_cluster_history(args: InitClusterHistory, client: RpcClient) {
+    // Creates cluster history account
+    let keypair = read_keypair_file(args.keypair_path).expect("Failed reading keypair file");
+
+    let mut instructions = vec![];
+    let (cluster_history_pda, _) =
+        Pubkey::find_program_address(&[ClusterHistory::SEED], &validator_history::ID);
+    instructions.push(Instruction {
+        program_id: validator_history::ID,
+        accounts: validator_history::accounts::InitializeClusterHistoryAccount {
+            cluster_history_account: cluster_history_pda,
+            system_program: solana_program::system_program::id(),
+            signer: keypair.pubkey(),
+        }
+        .to_account_metas(None),
+        data: validator_history::instruction::InitializeClusterHistoryAccount {}.data(),
+    });
+    // Realloc insturctions
+    let num_reallocs = (ClusterHistory::SIZE - MAX_ALLOC_BYTES) / MAX_ALLOC_BYTES + 1;
+    instructions.extend(vec![
+        Instruction {
+            program_id: validator_history::ID,
+            accounts: validator_history::accounts::ReallocClusterHistoryAccount {
+                cluster_history_account: cluster_history_pda,
+                system_program: solana_program::system_program::id(),
+                signer: keypair.pubkey(),
+            }
+            .to_account_metas(None),
+            data: validator_history::instruction::ReallocClusterHistoryAccount {}.data(),
+        };
+        num_reallocs
+    ]);
 
     let blockhash = client
         .get_latest_blockhash()
@@ -427,12 +504,53 @@ fn command_history(args: History, client: RpcClient) {
     }
 }
 
+fn command_backfill_cluster_history(args: BackfillClusterHistory, client: RpcClient) {
+    // Backfill cluster history account for a specific epoch
+    let keypair = read_keypair_file(args.keypair_path).expect("Failed reading keypair file");
+
+    let mut instructions = vec![];
+    let (cluster_history_pda, _) =
+        Pubkey::find_program_address(&[ClusterHistory::SEED], &validator_history::ID);
+    let (config, _) = Pubkey::find_program_address(&[Config::SEED], &validator_history::ID);
+    instructions.push(Instruction {
+        program_id: validator_history::ID,
+        accounts: validator_history::accounts::BackfillTotalBlocks {
+            cluster_history_account: cluster_history_pda,
+            config,
+            signer: keypair.pubkey(),
+        }
+        .to_account_metas(None),
+        data: validator_history::instruction::BackfillTotalBlocks {
+            epoch: args.epoch,
+            blocks_in_epoch: args.blocks_in_epoch,
+        }
+        .data(),
+    });
+
+    let blockhash = client
+        .get_latest_blockhash()
+        .expect("Failed to get recent blockhash");
+    let transaction = Transaction::new_signed_with_payer(
+        &instructions,
+        Some(&keypair.pubkey()),
+        &[&keypair],
+        blockhash,
+    );
+
+    let signature = client
+        .send_and_confirm_transaction_with_spinner(&transaction)
+        .expect("Failed to send transaction");
+    println!("Signature: {}", signature);
+}
+
 fn main() {
     let args = Args::parse();
     let client = RpcClient::new_with_timeout(args.json_rpc_url.clone(), Duration::from_secs(60));
     match args.commands {
         Commands::InitConfig(args) => command_init_config(args, client),
         Commands::CrankerStatus(args) => command_cranker_status(args, client),
+        Commands::InitClusterHistory(args) => command_init_cluster_history(args, client),
         Commands::History(args) => command_history(args, client),
+        Commands::BackfillClusterHistory(args) => command_backfill_cluster_history(args, client),
     };
 }


### PR DESCRIPTION
Cluster History Struct: 
* Sets up new account type: ClusterHistory
* Reads number of landed blocks from SlotHistory for last epoch
* Adds support for cranking this per epoch
* Backfill instruction + CLI command for filling in data since epoch 500
